### PR TITLE
feat(gradle): enable parallel execution of both tasks and tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.lang.Runtime
+
 plugins {
     kotlin("jvm") version "2.0.21"
     id("io.github.goooler.shadow") version "8.1.8"
@@ -50,6 +52,7 @@ tasks {
 
     test {
         useJUnitPlatform()
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     }
 
     jacoco {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.parallel=true


### PR DESCRIPTION
This pull request includes a small change to the `gradle.properties` file. The change enables parallel execution of tasks in Gradle.

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R1): Added the property `org.gradle.parallel=true` to enable parallel execution of tasks.